### PR TITLE
Add packaging metadata for editable installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ NAI Prompt Explorer は、PNG ファイルに埋め込まれたプロンプト�
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # Windows の場合は .venv\Scripts\activate
-pip install -r requirements.txt
+pip install -e .
 ```
 
 ## 使い方

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "naipromptexplorer"
+version = "0.1.0"
+description = "Desktop application for browsing prompts embedded in PNG files."
+readme = "README.md"
+authors = [{name = "NAI Prompt Explorer"}]
+license = {text = "MIT"}
+requires-python = ">=3.10"
+dependencies = [
+    "Pillow>=10.0.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Summary
- add a pyproject.toml so setuptools installs the package from the src layout
- document editable installation in the setup instructions

## Testing
- `pip install -e .` *(fails in the execution environment: unable to download build dependency `setuptools>=61` because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d10b35c21883299c9a3e73a26da71b