### PR TITLE
Fix indentation in thumbnail view

### DIFF
--- a/src/naipromptexplorer/thumbnail_view.py
+++ b/src/naipromptexplorer/thumbnail_view.py
@@ -239,8 +239,9 @@ class ThumbnailView(ttk.Frame):
         except tk.TclError:
             return
         margin = max(128, self.thumbnail_size)
-
-                item.ensure_thumbnail()
-            else:
+        for item, top, bottom in zip(self._items, self._item_tops, self._item_bottoms):
+            if bottom < canvas_top - margin or top > canvas_bottom + margin:
                 item.clear_thumbnail()
+            else:
+                item.ensure_thumbnail()
 


### PR DESCRIPTION
## Summary
- normalize the indentation in the thumbnail selection handler
- restore the viewport thumbnail loop to use consistent indentation

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d11b36f7648329b909313b6df2a6d8